### PR TITLE
Add webpack output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # SECRETS
 .env
+
+# WEBPACK
+dist/main.js


### PR DESCRIPTION
Add "dist/main.js" to .gitignore to avoid tracking webpack output bundle for production.